### PR TITLE
Add anomaly detection training function and make resources downloadable

### DIFF
--- a/opaque/download.py
+++ b/opaque/download.py
@@ -1,0 +1,20 @@
+import os
+import wget
+
+from opaque.locations import OPAQUE_HOME
+from opaque.locations import S3_BUCKET_URL
+from opaque.locations import BACKGROUND_DICTIONARY_PATH
+
+
+def download_background_dictionary():
+    wget.download(
+        url=f"{S3_BUCKET_URL}/entrez_pubmed_dictionary.pkl",
+        out=BACKGROUND_DICTIONARY_PATH
+    )
+
+
+if __name__ == "__main__":
+    if not os.path.exists(OPAQUE_HOME):
+        os.makedirs(OPAQUE_HOME)
+    if not os.path.exists(BACKGROUND_DICTIONARY_PATH):
+        download_background_dictionary()

--- a/opaque/download.py
+++ b/opaque/download.py
@@ -1,9 +1,12 @@
+import argparse
 import os
+import subprocess
 import wget
 
+from opaque.locations import BACKGROUND_DICTIONARY_PATH
+from opaque.locations import NEGATIVE_SET_PATH
 from opaque.locations import OPAQUE_HOME
 from opaque.locations import S3_BUCKET_URL
-from opaque.locations import BACKGROUND_DICTIONARY_PATH
 
 
 def download_background_dictionary():
@@ -13,8 +16,25 @@ def download_background_dictionary():
     )
 
 
+def download_negative_set():
+    compressed_path = NEGATIVE_SET_PATH + ".xz"
+    wget.download(
+        url=f"{S3_BUCKET_URL}/negative_set.json.xz",
+        out=compressed_path,
+    )
+    subprocess.run(
+        ["xz", "-v", "--decompress", "-1", compressed_path]
+    )
+
+
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Download resource files.")
+    parser.add_argument("--force", action="store_true", default=False)
+    args = parser.parse_args()
+    force = args.force
     if not os.path.exists(OPAQUE_HOME):
         os.makedirs(OPAQUE_HOME)
-    if not os.path.exists(BACKGROUND_DICTIONARY_PATH):
+    if force or not os.path.exists(BACKGROUND_DICTIONARY_PATH):
         download_background_dictionary()
+    if force or not os.path.exists(NEGATIVE_SET_PATH):
+        download_negative_set()

--- a/opaque/download.py
+++ b/opaque/download.py
@@ -10,9 +10,13 @@ from opaque.locations import S3_BUCKET_URL
 
 
 def download_background_dictionary():
+    compressed_path = BACKGROUND_DICTIONARY_PATH + ".xz"
     wget.download(
-        url=f"{S3_BUCKET_URL}/entrez_pubmed_dictionary.pkl",
-        out=BACKGROUND_DICTIONARY_PATH
+        url=f"{S3_BUCKET_URL}/background_dictionary.pkl.xz",
+        out=compressed_path,
+    )
+    subprocess.run(
+        ["xz", "-v", "--decompress", "-1", compressed_path]
     )
 
 
@@ -34,7 +38,12 @@ if __name__ == "__main__":
     force = args.force
     if not os.path.exists(OPAQUE_HOME):
         os.makedirs(OPAQUE_HOME)
-    if force or not os.path.exists(BACKGROUND_DICTIONARY_PATH):
+    if force:
+        if os.path.exists(BACKGROUND_DICTIONARY_PATH):
+            os.remove(BACKGROUND_DICTIONARY_PATH)
+        if os.path.exists(NEGATIVE_SET_PATH):
+            os.remove(NEGATIVE_SET_PATH)
+    if not os.path.exists(BACKGROUND_DICTIONARY_PATH):
         download_background_dictionary()
-    if force or not os.path.exists(NEGATIVE_SET_PATH):
+    if not os.path.exists(NEGATIVE_SET_PATH):
         download_negative_set()

--- a/opaque/download.py
+++ b/opaque/download.py
@@ -10,13 +10,9 @@ from opaque.locations import S3_BUCKET_URL
 
 
 def download_background_dictionary():
-    compressed_path = BACKGROUND_DICTIONARY_PATH + ".xz"
     wget.download(
-        url=f"{S3_BUCKET_URL}/background_dictionary.pkl.xz",
-        out=compressed_path,
-    )
-    subprocess.run(
-        ["xz", "-v", "--decompress", "-1", compressed_path]
+        url=f"{S3_BUCKET_URL}/{os.path.basename(BACKGROUND_DICTIONARY_PATH)}",
+        out=BACKGROUND_DICTIONARY_PATH,
     )
 
 

--- a/opaque/locations.py
+++ b/opaque/locations.py
@@ -1,6 +1,14 @@
 """Stores locations of resources used by opaque."""
 import os
+from appdirs import user_data_dir
 
 here = os.path.dirname(os.path.realpath(__file__))
 
+OPAQUE_HOME = os.environ.get("OPAQUE_HOME")
+if OPAQUE_HOME is None:
+    OPAQUE_HOME = os.path.join(user_data_dir(), 'opaque')
+BACKGROUND_DICTIONARY_PATH = os.path.join(
+    OPAQUE_HOME, "entrez_pubmed_dictionary.pkl"
+)
 TEST_DATA_LOCATION = os.path.join(here, "tests", "data")
+S3_BUCKET_URL = "https://adeft.s3.amazonaws.com/opaque"

--- a/opaque/locations.py
+++ b/opaque/locations.py
@@ -8,7 +8,7 @@ OPAQUE_HOME = os.environ.get("OPAQUE_HOME")
 if OPAQUE_HOME is None:
     OPAQUE_HOME = os.path.join(user_data_dir(), 'opaque')
 BACKGROUND_DICTIONARY_PATH = os.path.join(
-    OPAQUE_HOME, "entrez_pubmed_dictionary.pkl"
+    OPAQUE_HOME, "background_dictionary.pkl"
 )
 NEGATIVE_SET_PATH = os.path.join(
     OPAQUE_HOME, "negative_set.json"

--- a/opaque/locations.py
+++ b/opaque/locations.py
@@ -10,5 +10,8 @@ if OPAQUE_HOME is None:
 BACKGROUND_DICTIONARY_PATH = os.path.join(
     OPAQUE_HOME, "entrez_pubmed_dictionary.pkl"
 )
+NEGATIVE_SET_PATH = os.path.join(
+    OPAQUE_HOME, "negative_set.json"
+)
 TEST_DATA_LOCATION = os.path.join(here, "tests", "data")
 S3_BUCKET_URL = "https://adeft.s3.amazonaws.com/opaque"

--- a/opaque/nlp/featurize.py
+++ b/opaque/nlp/featurize.py
@@ -63,7 +63,7 @@ class BaselineTfidfVectorizer(BaseEstimator, TransformerMixin):
         dictionary = Dictionary.load(self.path)
         # Filter out tokens by their frequency.
         dictionary.filter_extremes(
-            no_above=self.no_above, no_below=self.no_below
+            no_above=self.no_above, no_below=self.no_below, keep_n=None
         )
         baseline_tfidf_model = TfidfModel(
             dictionary=dictionary, **self.tfidf_params
@@ -161,7 +161,7 @@ class BaselineTfidfVectorizer(BaseEstimator, TransformerMixin):
         ]
 
     @classmethod
-    def load_model_info(cls, path, model_info):
+    def load_model_info(cls, model_info, path=BACKGROUND_DICTIONARY_PATH):
         tokens = model_info["tokens"]
         tfidf = BaselineTfidfVectorizer(path)
         dictionary = Dictionary.load(path)

--- a/opaque/nlp/featurize.py
+++ b/opaque/nlp/featurize.py
@@ -9,6 +9,8 @@ from sklearn.utils.validation import check_is_fitted
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.feature_extraction.text import TfidfVectorizer
 
+from opaque.locations import BACKGROUND_DICTIONARY_PATH
+
 logging.getLogger("gensim").setLevel("WARNING")
 
 
@@ -17,7 +19,7 @@ class BaselineTfidfVectorizer(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    dict_path : str
+    path : str
         Path to pickle serialized gensim Dictionary
     max_features_per_class : Optional[int|float|callable]
         Maximum number of features taken per class in the training data.
@@ -28,7 +30,7 @@ class BaselineTfidfVectorizer(BaseEstimator, TransformerMixin):
 
     def __init__(
             self,
-            path,
+            path=BACKGROUND_DICTIONARY_PATH,
             no_above=0.5,
             no_below=5,
             max_features_per_class=None,

--- a/opaque/nlp/models.py
+++ b/opaque/nlp/models.py
@@ -1,5 +1,9 @@
 from sklearn.pipeline import Pipeline
 
+from opaque.locations import BACKGROUND_DICTIONARY_PATH
+from opaque.nlp.featurize import BaselineTfidfVectorizer
+from opaque.ood.svm import LinearOneClassSVM
+
 
 class GroundingAnomalyDetector:
     def __init__(self, featurizer, out_of_dist_classifier, memory=None):
@@ -32,13 +36,17 @@ class GroundingAnomalyDetector:
     @classmethod
     def load_model_info(
             cls,
-            featurizer_class,
-            out_of_dist_classifier_class,
-            featurizer_path,
-            model_info
+            model_info,
+            featurizer_class=None,
+            out_of_dist_classifier_class=None,
+            featurizer_path=BACKGROUND_DICTIONARY_PATH,
     ):
+        if featurizer_class is None:
+            featurizer_class = BaselineTfidfVectorizer
+        if out_of_dist_classifier_class is None:
+            out_of_dist_classifier_class = LinearOneClassSVM
         featurizer = featurizer_class.load_model_info(
-            featurizer_path, model_info["featurize"]
+            model_info["featurize"], path=featurizer_path
         )
         out_of_dist = out_of_dist_classifier_class.load_model_info(
             model_info["ood"]

--- a/opaque/train.py
+++ b/opaque/train.py
@@ -78,6 +78,7 @@ def train_anomaly_detector(
     ad_model.fit(train_texts)
     return {
         "model": ad_model.get_model_info(),
-        "stats": stats,
+        "train_stats": stats,
         "best_params": {"nu": best_nu, "max_features": best_max_features},
+        "num_training_texts": len(train_texts),
     }

--- a/opaque/train.py
+++ b/opaque/train.py
@@ -1,0 +1,83 @@
+from itertools import product
+import json
+
+import numpy as np
+from sklearn.model_selection import KFold
+
+from opaque.locations import BACKGROUND_DICTIONARY_PATH
+from opaque.locations import NEGATIVE_SET_PATH
+from opaque.nlp.featurize import BaselineTfidfVectorizer
+from opaque.nlp.models import GroundingAnomalyDetector
+from opaque.ood.svm import LinearOneClassSVM
+
+
+def train_anomaly_detector(
+        agent_texts,
+        train_texts,
+        nu_vals,
+        max_features_vals,
+        n_folds=5,
+        negative_texts=None,
+        no_above=0.05,
+        no_below=5,
+        random_state=None,
+):
+    if negative_texts is None:
+        with open(NEGATIVE_SET_PATH) as f:
+            negative_texts = json.load(f)
+    stats = {}
+    for nu, max_features in product(nu_vals, max_features_vals):
+        ad_model = GroundingAnomalyDetector(
+            BaselineTfidfVectorizer(
+                BACKGROUND_DICTIONARY_PATH,
+                max_features_per_class=max_features,
+                no_above=no_above,
+                no_below=no_below,
+                stop_words=agent_texts,
+                smartirs="ntc",
+            ),
+            LinearOneClassSVM(nu=nu)
+        )
+        kfold = KFold(n_splits=5, shuffle=True, random_state=random_state)
+        splits = kfold.split(train_texts)
+        spec_list = []
+        for train, test in splits:
+            ad_model.fit(
+                [
+                    text for i, text in enumerate(train_texts) if i in train
+                ]
+            )
+            preds_pos = ad_model.predict(
+                [
+                    text for i, text in enumerate(train_texts) if i in test
+                ]
+            ).flatten()
+            spec_list.append(sum(preds_pos == 1.0) / len(preds_pos))
+        preds_neg = ad_model.predict(negative_texts.values()).flatten()
+        sens = sum(preds_neg == -1.0) / len(preds_neg)
+        mean_spec = np.mean(spec_list)
+        std_spec = np.std(spec_list)
+        J = sens + mean_spec - 1
+        stats[(nu, max_features)] = (
+            sens, sum(preds_neg == 1.0), mean_spec, std_spec, J
+        )
+    # Choose values of nu and max features that maximize J
+    best_params = max(stats.items(), key=lambda x: x[1][4])[0]
+    best_nu, best_max_features = best_params
+    ad_model = GroundingAnomalyDetector(
+        BaselineTfidfVectorizer(
+            BACKGROUND_DICTIONARY_PATH,
+            max_features_per_class=best_max_features,
+            no_above=no_above,
+            no_below=no_below,
+            stop_words=agent_texts,
+            smartirs="ntc",
+        ),
+        LinearOneClassSVM(nu=best_nu)
+    )
+    ad_model.fit(train_texts)
+    return {
+        "model": ad_model.get_model_info(),
+        "stats": stats,
+        "best_params": {"nu": best_nu, "max_features": best_max_features},
+    }


### PR DESCRIPTION
This PR implements `opaque.train`, which contains the function `train_anomaly_detector` automating the portion of the anomaly detection workflow that is agnostic of the source of content. It uses 5-fold cross validation on the training data of the one class classifier to estimate specificity and makes predictions on a "negative sample" of texts. A negative sample has been made available through the new submodule `opaque.download` along with a background dictionary for use in the `opaque.nlp.featurize.BaselineTfidfVectorizer`. The background dictionary was built from the corpus of all texts with entrez annotations or MeSH annotations for MeSH terms with a mapping from Uniprot to MeSH in Indra's bio-ontology, or in the Javert xrefs database. The negative sample is a sample of 50,000 fulltexts from the corpus used to construct the background dictionary.

Opaque is closer to becoming a standalone package. Documentation pending. There isn't time yet.