### PR TITLE
Weighted regression

### DIFF
--- a/opaque/betabinomial_regression.py
+++ b/opaque/betabinomial_regression.py
@@ -1,15 +1,21 @@
 import numpy as np
+import pickle
 import pymc3 as pm
+from typing import NamedTuple
+
+from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
 
+from opaque.ood.utils import AnyMethodPipeline
 
-class BetaBinomialRegressor:
+
+class BetaBinomialRegressor(BaseEstimator, RegressorMixin):
     def __init__(
-        self,
-        coefficient_prior_type="normal",
-        coefficient_prior_scale=100.0,
-        intercept_prior_scale=1000.0,
-        **sampler_args
+            self,
+            coefficient_prior_type="normal",
+            coefficient_prior_scale=100.0,
+            intercept_prior_scale=1000.0,
+            **sampler_args,
     ):
         self.coefficient_prior_type = coefficient_prior_type
         self.coefficient_prior_scale = coefficient_prior_scale
@@ -74,10 +80,16 @@ class BetaBinomialRegressor:
                 )
             elif self.coefficient_prior_type == "laplace":
                 coef_mean = pm.Laplace(
-                    "coef_mean", self.coefficient_prior_scale, shape=ncols_mean
+                    "coef_mean",
+                    mu=0,
+                    b=self.coefficient_prior_scale,
+                    shape=ncols_mean,
                 )
                 coef_disp = pm.Laplace(
-                    "coef_disp", self.coefficient_prior_scale, shape=ncols_disp
+                    "coef_disp",
+                    mu=0,
+                    b=self.coefficient_prior_scale,
+                    shape=ncols_disp,
                 )
             else:
                 ValueError(
@@ -130,16 +142,189 @@ class BetaBinomialRegressor:
                 )
         return post_pred
 
-    def predict(self, X, N):
+    def predict(self, X, N=None):
+        if N is None:
+            N = np.ones(size=(X.shape[0]))
         post_pred = self.get_posterior_predictions(X, N, var_names=["K_est"])
-        return np.mean(post_pred["K_est"], axis=0)
+        preds = np.mean(post_pred["K_est"], axis=0)
+        return np.vstack([N, preds]).T
 
     def predict_shape_params(self, X):
         X = check_array(X)
-        N = np.full(X.shape[0], 1000)
+        N = np.full(X.shape[0], 1)
         post_pred = self.get_posterior_predictions(X, N)
-        mu = np.mean(post_pred["mu"], axis=0)
-        nu = np.mean(post_pred["nu"], axis=0)
-        alpha = mu * nu
-        beta = (1 - mu) * nu
-        return np.vstack([alpha, beta]).T
+        mu_sample = post_pred["mu"]
+        nu_sample = post_pred["nu"]
+        alpha_sample = mu_sample * nu_sample
+        beta_sample = (1 - mu_sample) * nu_sample
+        alpha = np.mean(alpha_sample, axis=0)
+        beta = np.mean(beta_sample, axis=0)
+        alpha_var = np.var(alpha_sample, axis=0)
+        beta_var = np.var(beta_sample, axis=0)
+        return (
+            np.vstack([alpha, beta]).T,
+            np.vstack([alpha_var, beta_var]).T,
+        )
+
+    def get_model_info(self):
+        check_is_fitted(self)
+        return {
+            'model': self.model_,
+            'trace': self.trace_,
+            'params': self.get_params(),
+            'sampler_args': self.sampler_args,
+            'mean_use_cols': self.mean_use_cols,
+            'disp_use_cols': self.disp_use_cols,
+        }
+
+    @classmethod
+    def load(cls, model_info):
+        params = model_info['params']
+        sampler_args = model_info['sampler_args']
+        instance = cls(**params, **sampler_args)
+        instance.model_ = model_info['model']
+        instance.trace_ = model_info['trace']
+        instance.mean_use_cols = model_info['mean_use_cols']
+        instance.disp_use_cols = model_info['disp_use_cols']
+        return instance
+
+
+class ShapeParamResults(NamedTuple):
+    sens_alpha: float
+    sens_beta: float
+    spec_alpha: float
+    spec_beta: float
+    sens_alpha_var: float
+    sens_beta_var: float
+    spec_alpha_var: float
+    spec_beta_var: float
+
+
+class DiagnosticTestPriorPredictor:
+    def __init__(
+            self,
+            sens_pipeline,
+            spec_pipeline,
+            validation=None,
+    ):
+        # Some basic validation. Each pipeline should have only two steps,
+        # a transformer and an estimator. Estimator should be a
+        # BetaBinomialRegressor model.
+        if validation is None or not isinstance(validation, dict):
+            validation = {}
+        self.__validation = validation
+
+        for pipeline in sens_pipeline, spec_pipeline:
+            assert len(pipeline.steps) == 2
+            transformer = pipeline.steps[0][1]
+            estimator = pipeline.steps[1][1]
+            check_is_fitted(transformer)
+            check_is_fitted(estimator)
+            assert isinstance(estimator, BetaBinomialRegressor)
+        self.sens_pipeline = sens_pipeline
+        self.spec_pipeline = spec_pipeline
+
+    @property
+    def validation(self):
+        return self.__validation
+
+    @property
+    def params(self):
+        sens_estimator = self.sens_pipeline.steps[1][1]
+        spec_estimator = self.spec_pipeline.steps[1][1]
+        sens_params = sens_estimator.get_params()
+        spec_params = spec_estimator.get_params()
+        sens_sampler_args = sens_estimator.sampler_args
+        spec_sampler_args = spec_estimator.sampler_args
+        params = {}
+        for key, value in sens_params:
+            params[f"sens__{key}"] = value
+        for key, value in spec_params:
+            params[f"spec__{key}"] = value
+        for key, value in sens_sampler_args:
+            params[f"sens__sampler__{key}"] = value
+        for key, value in spec_sampler_args:
+            params[f"spec__sampler__{key}"] = value
+        return params
+
+    def predict_shape_params(
+            self,
+            nu,
+            max_features,
+            log_num_entrez,
+            log_num_mesh,
+            sens_neg_set,
+            mean_spec,
+            std_spec,
+    ):
+        X = np.array(
+            [
+                [
+                    nu,
+                    max_features,
+                    log_num_entrez,
+                    log_num_mesh,
+                    sens_neg_set,
+                    mean_spec,
+                    std_spec,
+                ]
+            ]
+        )
+        sens_shape, sens_shape_var = self.sens_pipeline.apply_method(
+            'predict_shape_params', X
+        )
+        spec_shape, spec_shape_var = self.spec_pipeline.apply_method(
+            'predict_shape_params', X
+        )
+        return ShapeParamResults(
+            sens_alpha=sens_shape[0, 0],
+            sens_beta=sens_shape[0, 1],
+            spec_alpha=spec_shape[0, 0],
+            spec_beta=spec_shape[0, 1],
+            sens_alpha_var=sens_shape_var[0, 0],
+            sens_beta_var=sens_shape_var[0, 1],
+            spec_alpha_var=spec_shape_var[0, 0],
+            spec_beta_var=spec_shape_var[0, 1],
+        )
+
+    def dump(self, filepath):
+        sens_estimator = self.sens_pipeline.steps[1][1]
+        sens_transformer = self.sens_pipeline.steps[0][1]
+        spec_estimator = self.spec_pipeline.steps[1][1]
+        spec_transformer = self.spec_pipeline.steps[0][1]
+        sens_model_info = sens_estimator.get_model_info()
+        spec_model_info = spec_estimator.get_model_info()
+        with open(filepath, 'wb') as file_handle:
+            pickle.dump(
+                {
+                    'sens_model_info': sens_model_info,
+                    'sens_transformer': sens_transformer,
+                    'spec_model_info': spec_model_info,
+                    'spec_transformer': spec_transformer,
+                },
+                file_handle,
+            )
+
+    @classmethod
+    def load(cls, filepath):
+        with open(filepath, 'rb') as f:
+            info = pickle.load(f)
+        sens_model_info = info['sens_model_info']
+        sens_transformer = info['sens_transformer']
+        spec_model_info = info['spec_model_info']
+        spec_transformer = info['spec_transformer']
+        sens_estimator = BetaBinomialRegressor.load(sens_model_info)
+        spec_estimator = BetaBinomialRegressor.load(spec_model_info)
+        sens_pipeline = AnyMethodPipeline(
+            [
+                ('transform', sens_transformer),
+                ('estimator', sens_estimator),
+            ]
+        )
+        spec_pipeline = AnyMethodPipeline(
+            [
+                ('transform', spec_transformer),
+                ('estimator', spec_estimator),
+            ]
+        )
+        return cls(sens_pipeline, spec_pipeline)

--- a/opaque/betabinomial_regression.py
+++ b/opaque/betabinomial_regression.py
@@ -200,7 +200,7 @@ class ShapeParamResults(NamedTuple):
     spec_beta_var: float
 
 
-class DiagnosticTestPriorPredictor:
+class DiagnosticTestPriorModel:
     def __init__(
             self,
             sens_pipeline,

--- a/opaque/betabinomial_regression.py
+++ b/opaque/betabinomial_regression.py
@@ -1,25 +1,20 @@
 import numpy as np
 import pymc3 as pm
-from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
 
 
-class BetaRegressor(BaseEstimator, RegressorMixin):
+class BetaBinomialRegressor:
     def __init__(
         self,
         coefficient_prior_type="normal",
         coefficient_prior_scale=100.0,
-        intercept_prior_type="normal",
         intercept_prior_scale=1000.0,
-        rescale_response=True,
         **sampler_args
     ):
         self.coefficient_prior_type = coefficient_prior_type
         self.coefficient_prior_scale = coefficient_prior_scale
-        self.intercept_prior_type = intercept_prior_type
         self.intercept_prior_scale = intercept_prior_scale
 
-        self.rescale_response = rescale_response
         self.mean_use_cols = None
         self.disp_use_cols = None
         self.model_ = None
@@ -30,90 +25,94 @@ class BetaRegressor(BaseEstimator, RegressorMixin):
             sampler_args["progressbar"] = False
         self.sampler_args = sampler_args
 
-    def fit(self, X, y, mean_use_cols=None, disp_use_cols=None):
+    def fit(
+            self,
+            X,
+            y,
+            mean_use_cols=None,
+            disp_use_cols=None,
+    ):
         self.mean_use_cols = mean_use_cols
         self.disp_use_cols = disp_use_cols
-        X, y = check_X_y(X, y)
-        if self.rescale_response:
-            y = (y * (len(y) - 1) + 0.5) / len(y)
+        X, y = check_array(X), check_array(y)
+        assert X.shape[0] == y.shape[0]
+        assert y.shape[1] == 2
+        N, K = y[:, 0], y[:, 1]
+
         with pm.Model() as model:
-            if self.intercept_prior_type == "normal":
-                int_mean = pm.Normal(
-                    "int_mean",
-                    0.0,
-                    self.intercept_prior_scale
-                )
-                int_disp = pm.Normal(
-                    "int_disp",
-                    0.0,
-                    self.intercept_prior_scale
-                    )
-            elif self.intercept_prior_type == "laplace":
-                int_mean = pm.Laplace("int_mean", self.intercept_prior_scale)
-                int_disp = pm.Laplace("int_disp", self.intercept_prior_scale)
-            else:
-                raise ValueError(
-                    'intercept_prior_type must be one of "normal" '
-                    'or "laplace"'
-                )
+            intercept_mean = pm.Normal(
+                "intercept_mean",
+                0.0,
+                self.intercept_prior_scale
+            )
+            intercept_disp = pm.Normal(
+                "intercept_disp",
+                0.0,
+                self.intercept_prior_scale
+            )
+
             X_mean = X[:] if mean_use_cols is None else X[:, mean_use_cols]
             X_disp = X[:] if disp_use_cols is None else X[:, disp_use_cols]
             ncols_mean = X_mean.shape[1]
             ncols_disp = X_disp.shape[1]
             X_mean_obs = pm.Data("X_mean_obs", X_mean)
             X_disp_obs = pm.Data("X_disp_obs", X_disp)
-            y_obs = pm.Data("y_obs", y)
+            N = pm.Data("N", N)
+            K_obs = pm.Data("K_obs", K)
             if self.coefficient_prior_type == "normal":
-                beta_mean = pm.Normal(
-                    "beta_mean",
+                coef_mean = pm.Normal(
+                    "coef_mean",
                     0.0,
                     self.coefficient_prior_scale,
                     shape=ncols_mean
                 )
-                beta_disp = pm.Normal(
-                    "beta_disp",
+                coef_disp = pm.Normal(
+                    "coef_disp",
                     0.0,
                     self.coefficient_prior_scale,
                     shape=ncols_disp
                 )
             elif self.coefficient_prior_type == "laplace":
-                beta_mean = pm.Laplace(
-                    "beta_mean", self.coefficient_prior_scale, shape=ncols_mean
+                coef_mean = pm.Laplace(
+                    "coef_mean", self.coefficient_prior_scale, shape=ncols_mean
                 )
-                beta_disp = pm.Laplace(
-                    "beta_disp", self.coefficient_prior_scale, shape=ncols_disp
+                coef_disp = pm.Laplace(
+                    "coef_disp", self.coefficient_prior_scale, shape=ncols_disp
                 )
             else:
                 ValueError(
                     'coefficient_prior_type must be one of "normal" '
                     'or "laplace"'
                 )
-            mu_est = pm.Deterministic(
-                "mu_est",
+            mu = pm.Deterministic(
+                "mu",
                 pm.math.invlogit(
-                    int_mean + pm.math.dot(X_mean_obs, beta_mean),
+                    intercept_mean + pm.math.dot(X_mean_obs, coef_mean),
                     )
             )
-            nu_est = pm.Deterministic(
-                "nu_est",
-                pm.math.exp(int_disp + pm.math.dot(X_disp_obs, beta_disp))
+            nu = pm.Deterministic(
+                "nu",
+                pm.math.exp(
+                    intercept_disp + pm.math.dot(X_disp_obs, coef_disp)
+                )
             )
-            y_est = pm.Beta(
-                "y_est",
-                alpha=mu_est * nu_est,
-                beta=(1 - mu_est) * nu_est,
-                observed=y_obs,
+            K_est = pm.BetaBinomial(
+                "K_est",
+                n=N,
+                alpha=mu * nu,
+                beta=(1 - mu) * nu,
+                observed=K_obs,
             )
             trace = pm.sample(**self.sampler_args)
             self.trace_ = trace
             self.model_ = model
 
-    def get_posterior_predictions(self, X, **pymc3_args):
+    def get_posterior_predictions(self, X, N, **pymc3_args):
         check_is_fitted(self)
         if "var_names" not in pymc3_args:
-            pymc3_args["var_names"] = ["y_est", "mu_est", "nu_est"]
+            pymc3_args["var_names"] = ["K_est", "mu", "nu"]
         mean_use_cols, disp_use_cols = self.mean_use_cols, self.disp_use_cols
-        X = check_array(X)
+        X, N = check_X_y(X, N)
         X_mean = X[:] if mean_use_cols is None else X[:, mean_use_cols]
         X_disp = X[:] if disp_use_cols is None else X[:, disp_use_cols]
         with self.model_:
@@ -121,24 +120,26 @@ class BetaRegressor(BaseEstimator, RegressorMixin):
                 {
                     "X_mean_obs": X_mean,
                     "X_disp_obs": X_disp,
-                    "y_obs": np.empty(len(X_mean)),
+                    "N": N,
+                    "K_obs": np.empty(len(X_mean)),
                 }
             )
             post_pred = pm.fast_sample_posterior_predictive(
                 self.trace_,
                 **pymc3_args
                 )
-
         return post_pred
 
-    def predict(self, X):
-        post_pred = self.get_posterior_predictions(X, var_names=["y_est"])
-        return np.mean(post_pred["y_est"], axis=0)
+    def predict(self, X, N):
+        post_pred = self.get_posterior_predictions(X, N, var_names=["K_est"])
+        return np.mean(post_pred["K_est"], axis=0)
 
     def predict_shape_params(self, X):
-        post_pred = self.get_posterior_predictions(X)
-        mu = np.mean(post_pred["mu_est"], axis=0)
-        nu = np.mean(post_pred["nu_est"], axis=0)
+        X = check_array(X)
+        N = np.full(X.shape[0], 1000)
+        post_pred = self.get_posterior_predictions(X, N)
+        mu = np.mean(post_pred["mu"], axis=0)
+        nu = np.mean(post_pred["nu"], axis=0)
         alpha = mu * nu
         beta = (1 - mu) * nu
         return np.vstack([alpha, beta]).T

--- a/opaque/download.py
+++ b/opaque/download.py
@@ -3,27 +3,34 @@ import os
 import subprocess
 import wget
 
-from opaque.locations import BACKGROUND_DICTIONARY_PATH
-from opaque.locations import NEGATIVE_SET_PATH
-from opaque.locations import OPAQUE_HOME
-from opaque.locations import S3_BUCKET_URL
+import opaque.locations as loc
 
 
 def download_background_dictionary():
     wget.download(
-        url=f"{S3_BUCKET_URL}/{os.path.basename(BACKGROUND_DICTIONARY_PATH)}",
-        out=BACKGROUND_DICTIONARY_PATH,
+        url=f"{loc.S3_BUCKET_URL}/"
+        f"{os.path.basename(loc.BACKGROUND_DICTIONARY_PATH)}",
+        out=loc.BACKGROUND_DICTIONARY_PATH,
     )
 
 
 def download_negative_set():
-    compressed_path = NEGATIVE_SET_PATH + ".xz"
+    compressed_path = loc.NEGATIVE_SET_PATH + ".xz"
     wget.download(
-        url=f"{S3_BUCKET_URL}/negative_set.json.xz",
+        url=f"{loc.S3_BUCKET_URL}/"
+        f"{os.path.basename(compressed_path)}",
         out=compressed_path,
     )
     subprocess.run(
         ["xz", "-v", "--decompress", "-1", compressed_path]
+    )
+
+
+def download_diagnostic_test_prior_model():
+    wget.download(
+        url=f"{loc.S3_BUCKET_URL}/"
+        f"{os.path.basename(loc.DIAGNOSTIC_TEST_PRIOR_MODEL_PATH)}",
+        out=loc.DIAGNOSTIC_TEST_PRIOR_MODEL_PATH,
     )
 
 
@@ -32,14 +39,19 @@ if __name__ == "__main__":
     parser.add_argument("--force", action="store_true", default=False)
     args = parser.parse_args()
     force = args.force
-    if not os.path.exists(OPAQUE_HOME):
-        os.makedirs(OPAQUE_HOME)
+    if not os.path.exists(loc.OPAQUE_HOME):
+        os.makedirs(loc.OPAQUE_HOME)
     if force:
-        if os.path.exists(BACKGROUND_DICTIONARY_PATH):
-            os.remove(BACKGROUND_DICTIONARY_PATH)
-        if os.path.exists(NEGATIVE_SET_PATH):
-            os.remove(NEGATIVE_SET_PATH)
-    if not os.path.exists(BACKGROUND_DICTIONARY_PATH):
+        for location in (
+                loc.BACKGROUND_DICTIONARY_PATH,
+                loc.DIAGNOSTIC_TEST_PRIOR_MODEL_PATH,
+                loc.NEGATIVE_SET_PATH,
+        ):
+            if os.path.exists(location):
+                os.remove(location)
+    if not os.path.exists(loc.BACKGROUND_DICTIONARY_PATH):
         download_background_dictionary()
-    if not os.path.exists(NEGATIVE_SET_PATH):
+    if not os.path.exists(loc.DIAGNOSTIC_TEST_PRIOR_MODEL_PATH):
+        download_diagnostic_test_prior_model()
+    if not os.path.exists(loc.NEGATIVE_SET_PATH):
         download_negative_set()

--- a/opaque/locations.py
+++ b/opaque/locations.py
@@ -13,5 +13,8 @@ BACKGROUND_DICTIONARY_PATH = os.path.join(
 NEGATIVE_SET_PATH = os.path.join(
     OPAQUE_HOME, "negative_set.json"
 )
+DIAGNOSTIC_TEST_PRIOR_MODEL_PATH = os.path.join(
+    OPAQUE_HOME, "prior_model.pkl",
+)
 TEST_DATA_LOCATION = os.path.join(here, "tests", "data")
 S3_BUCKET_URL = "https://adeft.s3.amazonaws.com/opaque"

--- a/opaque/simulations/end_to_end.py
+++ b/opaque/simulations/end_to_end.py
@@ -141,9 +141,9 @@ class EndtoEndSimulator:
         spec_train = data_train[['N_inlier', 'K_inlier']].values
         br = BetaBinomialRegressor()
         br.fit(X_train, sens_train)
-        sens_shape = br.predict_shape_params(X_test)
+        sens_shape, _ = br.predict_shape_params(X_test)
         br.fit(X_train, spec_train)
-        spec_shape = br.predict_shape_params(X_test)
+        spec_shape, _ = br.predict_shape_params(X_test)
         points = []
         rows = []
         for i, row in data_test.iterrows():

--- a/opaque/train.py
+++ b/opaque/train.py
@@ -5,10 +5,13 @@ import numpy as np
 from sklearn.model_selection import KFold
 
 from opaque.locations import BACKGROUND_DICTIONARY_PATH
+from opaque.locations import DIAGNOSTIC_TEST_PRIOR_MODEL_PATH
 from opaque.locations import NEGATIVE_SET_PATH
 from opaque.nlp.featurize import BaselineTfidfVectorizer
 from opaque.nlp.models import GroundingAnomalyDetector
 from opaque.ood.svm import LinearOneClassSVM
+
+from opaque.betabinomial_regression import DiagnosticTestPriorModel
 
 
 def train_anomaly_detector(
@@ -21,6 +24,9 @@ def train_anomaly_detector(
         no_above=0.05,
         no_below=5,
         random_state=None,
+        predict_shape_params=False,
+        num_mesh_texts=None,
+        num_entrez_texts=None,
 ):
     if negative_texts is None:
         with open(NEGATIVE_SET_PATH) as f:
@@ -76,9 +82,48 @@ def train_anomaly_detector(
         LinearOneClassSVM(nu=best_nu)
     )
     ad_model.fit(train_texts)
+    features = None
+    if (
+            num_mesh_texts is not None and
+            num_entrez_texts is not None and
+            isinstance(num_mesh_texts, int) and
+            isinstance(num_entrez_texts, int)
+    ):
+        log_num_mesh = np.log(num_mesh_texts + 1)
+        log_num_entrez = np.log(num_entrez_texts + 1)
+        best_params = (best_nu, best_max_features)
+        sens_neg_set, _, mean_spec, std_spec, _ = stats[best_params]
+        features = [
+            best_nu,
+            best_max_features,
+            log_num_entrez,
+            log_num_mesh,
+            sens_neg_set,
+            mean_spec,
+            std_spec,
+        ]
+    shape_params = None
+    if predict_shape_params and features is not None:
+        prior_model = DiagnosticTestPriorModel.load(
+            DIAGNOSTIC_TEST_PRIOR_MODEL_PATH,
+        )
+        sp = prior_model.predict_shape_params(**features)
+        shape_params = {
+            "sens_alpha": sp.sens_alpha,
+            "sens_beta": sp.sens_beta,
+            "spec_alpha": sp.spec_alpha,
+            "spec_beta": sp.spec_beta,
+            "sens_alpha_var": sp.sens_alpha_var,
+            "sens_beta_var": sp.sens_beta_var,
+            "spec_alpha_var": sp.spec_alpha_var,
+            "spec_beta_var": sp.spec_beta_var,
+        }
+
     return {
         "model": ad_model.get_model_info(),
         "train_stats": stats,
         "best_params": {"nu": best_nu, "max_features": best_max_features},
         "num_training_texts": len(train_texts),
+        "shape_params": shape_params,
+        "features": features,
     }

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "cython",
         "scikit-learn",
         "statsmodels",
-        "pymc3",
+        "pymc3==3.11.0",
         "numba",
         "liblinear-official",
     ],


### PR DESCRIPTION
This PR updates the model to predict the priors for sensitivity and specificity of an anomaly detector to use betabinomial-regression instead of beta regression. In the latter, the targets are proportions between 0 and 1, in the former the target values are pairs (N, K) where N is the number of trials and K the number of successes. Using betabinomial regression is the natural choice to use, since the gold-standard data taken from texts with defining patterns found through adeft estimates sensitivity (or specificity) by making predictions on texts known to be anomalous (or not anomalous) and finding the number that are predicted to be anomalous. Taking the proportions as targets gives disproportionate weight to examples with a small number of gold standard texts. It was an oversight not to use betabinomial regression from the start.

A metric has also been implemented for scoring the accuracy of a betabinomial regression. Square residuals (K_true - K_predicted)^2 for (N, K_true), (N, K_predicted) are standardized by the variance `N(K_true/N)(1 - K_true/N)`, so that the units are taken to be in terms of standard scores. This metric has support in the literature, but I'll need to dig for a proper citation.

A pre-trained prior prediction model has been placed on S3, and code has been added to allow it to be downloaded to a users machine. This model has been integrated into `opaque.train`, to allow the option of predicting the shape parameters of an anomaly detector at the time of training.