### PR TITLE
Add pymc3 serialization and fix a bug

### DIFF
--- a/opaque/betabinomial_regression.py
+++ b/opaque/betabinomial_regression.py
@@ -6,7 +6,9 @@ from typing import NamedTuple
 from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
 
-from opaque.ood.utils import AnyMethodPipeline
+from opaque.utils import AnyMethodPipeline
+from opaque.utils import dump_trace
+from opaque.utils import load_trace
 
 
 class BetaBinomialRegressor(BaseEstimator, RegressorMixin):

--- a/opaque/betabinomial_regression.py
+++ b/opaque/betabinomial_regression.py
@@ -172,7 +172,7 @@ class BetaBinomialRegressor(BaseEstimator, RegressorMixin):
         check_is_fitted(self)
         return {
             'model': self.model_,
-            'trace': self.trace_,
+            'trace': dump_trace(self.trace_),
             'params': self.get_params(),
             'sampler_args': self.sampler_args,
             'mean_use_cols': self.mean_use_cols,
@@ -185,7 +185,7 @@ class BetaBinomialRegressor(BaseEstimator, RegressorMixin):
         sampler_args = model_info['sampler_args']
         instance = cls(**params, **sampler_args)
         instance.model_ = model_info['model']
-        instance.trace_ = model_info['trace']
+        instance.trace_ = load_trace(model_info['trace'])
         instance.mean_use_cols = model_info['mean_use_cols']
         instance.disp_use_cols = model_info['disp_use_cols']
         return instance

--- a/opaque/ood/svm.py
+++ b/opaque/ood/svm.py
@@ -9,7 +9,7 @@ from sklearn.utils.validation import check_is_fitted
 from liblinear.liblinearutil import parameter, problem, train
 
 
-from opaque.ood.utils import load_array, serialize_array
+from opaque.utils import load_array, serialize_array
 
 
 class LinearOneClassSVM(BaseEstimator, OutlierMixin):

--- a/opaque/train.py
+++ b/opaque/train.py
@@ -107,7 +107,7 @@ def train_anomaly_detector(
         prior_model = DiagnosticTestPriorModel.load(
             DIAGNOSTIC_TEST_PRIOR_MODEL_PATH,
         )
-        sp = prior_model.predict_shape_params(**features)
+        sp = prior_model.predict_shape_params(*features)
         shape_params = {
             "sens_alpha": sp.sens_alpha,
             "sens_beta": sp.sens_beta,


### PR DESCRIPTION
This PR allows pymc3 models to be serialized correctly. It also fixes a typo that made it so that shape parameter prediction fails in the train function.